### PR TITLE
Added support for asynchronous level

### DIFF
--- a/jasper.asks.js
+++ b/jasper.asks.js
@@ -96,6 +96,19 @@ Jasper("ask"
     return obj.jasper && /function/i.test({}.toString.call(obj.jasper)) && !obj.hasOwnProperty("jasper");
   });
 
+Jasper("ask"
+, "Pass in a function that execute the functions passed in argument aftyer 1s"
+, "Asynchronous execution + scopes."
+  , function (done, cb) {
+  	var execs=0;
+  	var fn=function() {
+  		++execs===3&&done();
+  	};
+  	cb(fn,fn,fn);
+    return null;
+  }
+  ,2000);
+
 // Jasper("ask", "", function () {});
 
 Jasper("ask"); // lock the list of asks

--- a/test/jasmine/asks.spec.js
+++ b/test/jasmine/asks.spec.js
@@ -94,4 +94,14 @@ describe('User ', function() {
     expect(feedback).not.toBe('Not quite try again.');
   });
 
+  it('should provide answer to async challenge', function() {
+    jasper('skip', 8);
+
+    var feedback = jasper(function(object) {
+      object.prototype.jasper = function() {};
+    });
+
+    expect(feedback).not.toBe('Not quite try again.');
+  });
+
 });


### PR DESCRIPTION
Hi,

I found Jasper was lacking of an asynchonous way to define levels.

Here is a fix for that. I tested everything i could with the current test config.

However, i suggest you to take a look to Sinon and sandboxing to be able to test console logs (asynchonously, this is the only way we have to give feedback to users). A blog post talking about that : https://nicolas.perriault.net/code/2013/testing-frontend-javascript-code-using-mocha-chai-and-sinon/

Hope you'll find it usefull.
